### PR TITLE
Fix missing keymapping on windows

### DIFF
--- a/PixelToasterWindows.h
+++ b/PixelToasterWindows.h
@@ -140,12 +140,12 @@ public:
 
         // setup keyboard data
 
-        for (bool& i : down)
+        for (int i=0;i<256;i++)
         {
             translate[i] = (Key::Code)i;
-            i            = false;
+            down[i] = false;
         }
-
+        
         translate[219] = Key::OpenBracket;
         translate[221] = Key::CloseBracket;
         translate[220] = Key::BackSlash;


### PR DESCRIPTION
A recent change to the windows version of pixeltoaster left the translate[] array of keypresses mostly unpopulated.  This rolls back the change to the for loop.